### PR TITLE
add \googleSheet command for embedding Google spreadsheets

### DIFF
--- a/ximera.4ht
+++ b/ximera.4ht
@@ -199,6 +199,19 @@
 \renewcommand{\desmos}[3]{\HCode{<a title="View with the Desmos Graphing Calculator" href="https://www.desmos.com/calculator/#1" target="_blank">  <img src="https://s3.amazonaws.com/calc_thumbs/production/#1.png"" width="#2px" height="#3px" style="border:1px solid \#ccc; border-radius:5px"/></a>}}
 
 
+% googleSheet command. Requires id, width, and height as arguments.
+%  optional arguments are gid for sheet ID and range for cell range.
+%command definition
+\renewcommand{\googleSheet}[5]{%
+  \ifthenelse{\equal{#4}{}}%
+    {\HCode{<iframe width="#2px" height="#3px" src="https://docs.google.com/spreadsheets/d/#1/htmlembed?widget=true">This browser does not support embedded elements.</iframe>}}%
+    {\ifthenelse{\equal{#5}{}}%
+       {\HCode{<iframe width="#2px" height="#3px" src="https://docs.google.com/spreadsheets/d/#1/htmlembed?single=true&amp;gid=#4&amp;widget=false">This browser does not support embedded elements.</iframe>}}%
+       {\HCode{<iframe width="#2px" height="#3px" src="https://docs.google.com/spreadsheets/d/#1/htmlembed?single=true&amp;gid=#4&amp;range=#5&amp;widget=false">This browser does not support embedded elements.</iframe>}}%
+    }%
+}%
+
+
 % HTML environment.
 %\renewcommand{\html}[1]{\HCode{#1}}
 \RenewEnviron{html}{\HCode{\BODY}}

--- a/ximera.cls
+++ b/ximera.cls
@@ -335,6 +335,11 @@
 %Desmos link
 \newcommand{\desmos}[3]{Desmos link: \url{https://www.desmos.com/calculator/#1}}
 
+% Google Spreadsheet link (read only)
+\newcommand{\googleSheet}[5]{%
+  Google Spreadsheet link: \url{https://docs.google.com/spreadsheets/d/#1}%
+}
+
 % Embedded graph (in math mode)
 \newcommand{\graph}[1]{\mbox{Graph of $#1$}}
 


### PR DESCRIPTION
This commit adds a new command, \googleSheet, which embeds a (read only) published Google Spreadsheet into a ximera document.

A live example and usage instructions are available at the following page:
http://ximera.osu.edu/course/397871481c336bc0a697d55e4f4075e2c79dc79f/test/test