### PR TITLE
Convert \emph to <em>

### DIFF
--- a/ximera.cfg
+++ b/ximera.cfg
@@ -56,7 +56,8 @@
 \Configure{textbf}{\ifvmode\ShowPar\fi\HCode{<strong>}}{\HCode{</strong>}}
 \Configure{textit}{\ifvmode\ShowPar\fi\HCode{<em>}}{\HCode{</em>}}
 \Configure{texttt}{\ifvmode\ShowPar\fi\HCode{<code>}}{\HCode{</code>}}
- 
+\Configure{emph}{\ifvmode\ShowPar\fi\HCode{<em>}}{\HCode{</em>}}
+
 % Translate verbatim and lstlisting blocks into <pre> elements
 \ConfigureEnv{verbatim}{\HCode{<pre>}}{\HCode{</pre>}}{}{}
 \ConfigureEnv{lstlisting}{\HCode{<pre>}}{\HCode{</pre>}}{}{}


### PR DESCRIPTION
This commit adds one line to convert the semantic \LaTeX2e command \emph{quux} to <em>quux</em>