### PR TITLE
Latest update

### DIFF
--- a/OptionalPackages/Sage to LaTeX Merge Tools/xronos/xronostools/xr_OutputHeader.txt
+++ b/OptionalPackages/Sage to LaTeX Merge Tools/xronos/xronostools/xr_OutputHeader.txt
@@ -1,7 +1,9 @@
 \documentclass[]{ximera}
 \usepackage{sagetex}
 \usepackage{PackageLoader}
+\renewenvironment{validator}[1]{}{}
+\renewenvironment{feedback}[1]{}{}
 \begin{document}
 \makeatletter
-\input{JasonSageMacros}
+\input{Useful-Sage-Macros}
 \renewcommand{\latexProblemContent}[1]{#1}

--- a/OptionalPackages/Sage to LaTeX Merge Tools/xronos/xronostools/xronostools.conf
+++ b/OptionalPackages/Sage to LaTeX Merge Tools/xronos/xronostools/xronostools.conf
@@ -37,7 +37,7 @@ XronosrawOutputDir = "./XronosOutput/"
 # This is the location that the problem banks will be built. Unless you are completely redesigning the Problem Bank file structure, this should *NOT* be modified.
 # XFinal_OutputDir sets the output directory for the xronosfinal process
 #   Used by xronosfinal - defaults to "./" 
-XFinal_OutputDir = "/home/jason/texmf/tex/Questions/"
+XFinal_OutputDir = "/home/jason/texmf/tex/latex/QuestionBanks/"
 
 
 
@@ -70,18 +70,22 @@ XF_QuestionsOnly = yes
 # if the placeholder appears, the entire line is replaced
 # the placeholder value is case sensitive
 #   Used by xronosraw - defaults to XTL_SV_HELPFILE
-# HelpFilePlaceHolder = HELPFILE
+#HelpFilePlaceHolder = HELPFILE
+
 
 ########## SAGE fixing flags
-### There are some quirks to how sagetex processes the sage code and tries to insert it into the latex file that break a substitution and/or break the natural ximera engine. These have been addressed by the problem converter, but in the event that sage is fixed at some point these flags will allow you to turn off the "fix" if it causes problems.
-
-
-#### By default sagetex processes any text string by passing it to a \text{ } environment (since sage is used in mathmode). Unfortunately latex has trouble parsing the resulting whitespace normally, and so to fix this sagetex introduced a \text{\texttt{ }} method to counter this, using {}'s to bracket off whitespace. Thus 'This is a phrase' becomes (in sagetex) \text{\texttt{This{ }is{ }a{ }phrase}}. Unfortunately for Ximera users, ximera parses the \text command correctly, resulting in the text published to html to be the string: "\texttt{This{ }is{ }a{ }phrase}". This flag removes the \texttt command and all contained {}'s while leaving white space. Note that if you need to have \text{\texttt{ } } in your code somewhere you a) Probably shouldn't do that, but b) you can get around this substitution fix by wrapping the command in another command used in a package. Thus you can use \newcommand{\txttt}[1]{\text{\texttt{#1}}} for example. 
-SageBug_Texttt_removal = yes
-
-#### For reasons I haven't figured out, sagetex does some truly weird behavior when sqrt root specifically is passed an optional argument when sage is involved. Thsi flag fixes this problem. The behavior is truly weird and is beyong the scope of explanation in this file, suffice it to say unless your option argument sqrt commands start doing crazy things, don't touch this flag.
+#### There are some quirks to how sagetex processes the sage code and tries to insert it into the latex file that break a substitution and/or break the natural ximera engine. These have been addressed by the problem converter, but in the event that sage is fixed at some point these flags will allow you to turn off the "fix" if it causes problems.
+#
+#
+##### By default sagetex processes any text string by passing it to a \text{ } environment (since sage is used in mathmode). Unfortunately latex has trouble parsing the resulting whitespace normally, and so to fix this sagetex introduced a \text{\texttt{ }} method to counter this, using {}'s to bracket off whitespace. Thus 'This is a phrase' becomes (in sagetex) \text{\texttt{This{ }is{ }a{ }phrase}}. Unfortunately for Ximera users, ximera parses the \text command correctly, resulting in the text published to html to be the string: "\texttt{This{ }is{ }a{ }phrase}". This flag removes the \texttt command and all contained {}'s while leaving white space. Note that if you need to have \text{\texttt{ } } in your code somewhere you a) Probably shouldn't do that, but b) you can get around this substitution fix by wrapping the command in another command used in a package. Thus you can use \newcommand{\txttt}[1]{\text{\texttt{#1}}} for example. 
+SageBug_Texttt_removal = "yes"
+#
+##### For reasons I haven't figured out, sagetex does some truly weird behavior when sqrt root specifically is passed an optional argument when sage is involved. Thsi flag fixes this problem. The behavior is truly weird and is beyong the scope of explanation in this file, suffice it to say unless your option argument sqrt commands start doing crazy things, don't touch this flag.
 SageBug_Sqrt = Yes
-
+#
+#
+#
+#
 ########## Cleanup and Logging variables
 
 # IndividualLogFiles breaks the xronosbatch.log file into a log file for each file processed
@@ -181,10 +185,10 @@ CleanupPDFAndSageFiles = yes
 #	These are structured in pairs, a search entry and a replace entry.  Both must exist or the 
 #	entry is ignored.  The entries go from 01 to 99, single digit numbers must have a leading 0.
 #
-#XF_USERSUB01_SEARCH = The Old String
+#XF_USERSUB01_SEARCH = "\texttt{Yes}" 
 #XF_USERSUB01_REPLACE = The New String
-#XF_USERSUB02_SEARCH = "The Old String2"
-#XF_USERSUB02_REPLACE = "The New String2"
+XF_USERSUB02_SEARCH = "\mathit{XTRtheta}"
+XF_USERSUB02_REPLACE = "\theta"
 #XF_USERSUB99_SEARCH = '"The Old String99"'
 #XF_USERSUB99_REPLACE = "'The New String99'"
 

--- a/OptionalPackages/devCompile.sty
+++ b/OptionalPackages/devCompile.sty
@@ -10,7 +10,8 @@
 
 \renewenvironment{feedback}[1]["None Given"]{
 Feedback Condition: \texttt{#1} \\
-Feedback Given:}{
+Feedback Given:\\ }{
+
 \hrule
 }
 
@@ -20,6 +21,7 @@ Validator Code Provided: \\
 
 End of Validator Code.
 }{
+
 \hrule
 }
 

--- a/ximera.cls
+++ b/ximera.cls
@@ -20,8 +20,8 @@
 %%% Department of Mathematics
 %%% The Ohio State University
 
-\def\fileversion{1.33}
-\def\filedate{2016/08/17}
+\def\fileversion{1.4}
+\def\filedate{2018/03/01}
 
 % ---------------------------------------------------------------------
 % ---------------------------------------------------------------------
@@ -97,7 +97,6 @@
 \DeclareOption{tikzexport}{%
   \tikzexporttrue%
   \handoutfalse%
-%  \shufflefalse%
   \spacefalse%  
   \numbersfalse%
   \newpagefalse%

--- a/ximera.cls
+++ b/ximera.cls
@@ -230,11 +230,14 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %Improved version of \newcounter to check for existance before creating a counter to minimize conflicts with packages.
+%
+% Added by Jason Nowell
 
 \newcommand{\Make@Counter}[1]{
 	\@ifundefined{c@#1}	% Check to see if counter exists
-		{									%If not, create it.
+		{									%If not, create it and set it to 0.
 		\newcounter{#1}
+		\setcounter{#1}{0}
 		}
 		{									%If so, reset to 0.
 		\setcounter{#1}{0}
@@ -564,44 +567,79 @@ Interactive
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \define@key{answer}{given}[true]{\def\ans@given{#1}}% Determines if answer is shown in handout mode.
-\define@key{answer}{tolerance}{\def\ans@tol{#1}}% Used for setting numeric answer tolerance for online student input. 
-												 %  Note: currently no affect on pdf output.
-\define@key{answer}{validator}{}%			Used to run dynamic js code on student provided answers.
-\define@key{answer}{id}{\def\ans@id{#1}} %	Used for assigning a js ID to answer for dynamic code (eg validators).
-												 %  Note: currently no affect on pdf output.
-\define@key{answer}{format}{}%				Used to set anticipated input format; eg "string".
-
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%	Set default values for answer command key=value pairs
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-\setkeys{answer}{id=,given=false}
-\newcommand{\answer}[2][]{%
-  \ifmmode%
-	\setkeys{answer}{#1}%
 	%% when given=true, show answer in handout mode, show answer in "given box" outside handout mode
 	%% when given=false, do not show answer in handout mode, show answer outside handout mode
-        \recordvariable{\ans@id}
-	\ifthenelse{\boolean{\ans@given}}
-		{\ifhandout #2\else\underset{\scriptstyle\mathrm{given}}{\fbox{\ensuremath{#2}}}\fi}
-		{\ifhandout\fbox{\rm{?}}\else\fbox{\ensuremath{#2}}\fi}% show answer in box outside handout mode
-  \else%
-  \GenericError{\space\space\space\space}
-  {Attempt to use \@backslashchar answer outside of math mode}
-  {See https://github.com/ximeraProject/ximeraLatex for explanation.}
-  {Need to use either inline or display math.}%
-  \fi
+
+\define@key{answer}{tolerance}{\def\ans@tol{#1}}% Used for setting numeric answer tolerance for online student input. 
+												 %  Note: currently no affect on pdf output.
+
+\define@key{answer}{validator}{}%			Used to run dynamic js code on student provided answers.
+												 %  Note: currently pdf outputs the validator code itself.
+
+\define@key{answer}{id}{\def\ans@id{#1}} %	Used for assigning a js ID to answer for dynamic code (eg validators).
+												 %  Note: currently no affect on pdf output.
+
+\define@key{answer}{format}{}%				Used to set anticipated input format; eg "string".
+												 %  Note: currently no affect on pdf output.
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%			Set default values for answer command key=value pairs
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Default values are:
+%
+% given = false
+
+\setkeys{answer}{id=,given=false}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%						Answer command base code.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+\newcommand{\answer}[2][]{%
+	\ifmmode%
+		\setkeys{answer}{#1}%
+		\recordvariable{\ans@id}
+		\ifthenelse{\boolean{\ans@given}}
+			{% Start then statement
+			\ifhandout 
+				#2
+			\else
+				\underset{\scriptstyle\mathrm{given}}{\fbox{\ensuremath{#2}}}
+			\fi
+			}% End then statement
+			{% Start else statement
+			\ifhandout
+				\fbox{\rm{?}}
+			\else% show answer in box outside handout mode
+				\fbox{\ensuremath{#2}}
+			\fi
+			}% End else statement
+	\else%
+		\GenericError{\space\space\space\space}% Throw an error based on... something? -- Jason
+		{Attempt to use \@backslashchar answer outside of math mode}
+		{See https://github.com/ximeraProject/ximeraLatex for explanation.}
+		{Need to use either inline or display math.}%
+	\fi
 }
              
 
 
-%% multiple choice environment
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%				Answer: Multiple Choice Environment.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 
 % Jim: Originally this was \renewcommand{\theenumi}{$(\mathrm{\alph{enumi}})$}
 % but that breaks tex4ht because mathmode can only be processed by mathjax.
 % so now I made this just italicized.
+
+%% Not sure what role these renewed commands make? -- Jason
 \renewcommand{\theenumi}{\textup{(\alph{enumi})}}
 \renewcommand{\labelenumi}{\theenumi}
 \renewcommand{\theenumii}{\textup{(\roman{enumii})}}
@@ -609,50 +647,110 @@ Interactive
 
 %% correct answers for multiple choice
 
+
+%%%%  key=value pairs for multiple choice options.
+
 \define@key{choice}{value}[]{\def\choice@value{#1}}
-\define@boolkey{choice}{correct}[true]{\def\choice@correct{#1}}
-\setkeys{choice}{correct=false,value=}
-\newcommand{\choice}[2][]{%
-\setkeys{choice}{#1}%
-\item{#2}\ifthenelse{\boolean{\choice@correct}}{\ifhandout \else \,\checkmark\,\setkeys{choice}{correct=false}\fi}{}}
-
-%Define an expandable version of choice
-\newcommand{\choiceEXP}[2][]{%
-\expandafter\setkeys\expandafter{choice}{#1}%
-\item{#2}\ifthenelse{\boolean{\choice@correct}}{\ifhandout \else \,\checkmark\,\setkeys{choice}{correct=false}\fi}{}} %% note all the {} are needed in case the choice has [] in it.
-
-
-%% Not really meant to be used outside this package (used in wordChoice)
-%% \otherchoice outputs the item if correct and nothing if incorrect.
-
-\define@key{otherchoice}{value}[]{\def\otherchoice@value{#1}}
-\define@boolkey{otherchoice}{correct}[true]{\def\otherchoice@correct{#1}}
-\setkeys{otherchoice}{correct=false,value=}
-\newcommand{\otherchoice}[2][]{%
-  \ignorespaces
-  \setkeys{otherchoice}{#1}
-  \ifthenelse{\boolean{\otherchoice@correct}}{#2\setkeys{otherchoice}{correct=false}}{}\ignorespaces}
-
-%%%
-
-%setting default values for multipleChoice command key=value pairs
+\define@boolkey{choice}{correct}[true]{\def\choice@correct{#1}}% This flags the answer as the correct answer
 
 \define@key{multipleChoice}{id}{\def\mc@id{#1}}
-\setkeys{multipleChoice}{id=}
+
+%% \otherchoice outputs the item if correct and nothing if incorrect.
+\define@key{otherchoice}{value}[]{\def\otherchoice@value{#1}}
+\define@boolkey{otherchoice}{correct}[true]{\def\otherchoice@correct{#1}}
+
+%%%%  Default key choices for multiple choice options.
+%
+% Default for choice pairs
+\setkeys{choice}{correct=false,value=}% Default: answers without the option "correct=true" is "incorrect".
+
+% Defaults for multipleChoice pairs.
+\setkeys{multipleChoice}{id=}% Default to no id? -- Jason
+
+% Defaults for otherchoice pairs.
+\setkeys{otherchoice}{correct=false,value=}% Default "otherchoice" to behave like "choice" for error checking.
+
+%%%%  Default choice command.
+%
+% choice command denotes a possible answer choice for the multiple choice question.
+
+\newcommand{\choice}[2][]{%
+	\setkeys{choice}{#1}%
+	\item{#2}
+	\ifthenelse{\boolean{\choice@correct}}
+		{% Begin then result
+		\ifhandout% if it's a handout do nothing.
+		\else% otherwise place a checkmark when you select the "correct choice"... maybe? -- Jason
+			\,\checkmark\,\setkeys{choice}{correct=false}
+		\fi
+		}% End then result
+		{}% Begin/End else result.
+		}
+
+%Define an expandable version of choice Not really meant to be used outside this package (used in wordChoice)
+% Is there a reason we can't just always use this as default? -- Jason
+\newcommand{\choiceEXP}[2][]{%
+	\expandafter\setkeys\expandafter{choice}{#1}%
+	\item{#2}
+	\ifthenelse{\boolean{\choice@correct}}
+		{% Begin then result
+		\ifhandout 
+		\else 
+			\,\checkmark\,\setkeys{choice}{correct=false}
+		\fi
+		}% End then result
+		{}% Begin/End else result.
+	} %% note all the {} are needed in case the choice has [] in it.
+
+
+
+
+\newcommand{\otherchoice}[2][]{%
+	\ignorespaces
+	\setkeys{otherchoice}{#1}
+	\ifthenelse{\boolean{\otherchoice@correct}}
+		{% Start then result
+		#2\setkeys{otherchoice}{correct=false}
+		}% End then result
+		{}% Start/End else result
+	\ignorespaces
+	}
+
+%%%%  multipleChoice Environment(s).
+%
+% multipleChoice* and multipleChoice** are for internal use only. 
+%% Given normal LaTeX syntax, we may want to change this to something more like 
+%% multipleChoice@ and multipleChoice@@. -- Jason
+
 
 \newenvironment{multipleChoice}[1][]
-{\setkeys{multipleChoice}{#1}%
-\recordvariable{\mc@id}%
-\begin{trivlist}\item[\hskip \labelsep\small\bfseries Multiple Choice:]\hfil\begin{enumerate}}
-{\end{enumerate}\end{trivlist}}
+	{% Environment Start Code
+	\setkeys{multipleChoice}{#1}%
+	\recordvariable{\mc@id}%
+	\begin{trivlist}
+		\item[\hskip \labelsep\small\bfseries Multiple Choice:]\hfil
+		\begin{enumerate}
+	}% Note this means that \item has to be the first line after \begin{multipleChoice}.
+	{% Environment End Code
+		\end{enumerate}
+	\end{trivlist}
+	}
 
 %multipleChoice* is for internal use only! (used in wordChoice)
 %It displays all choices in a list separated by /
 \newenvironment{multipleChoice*}[1][]
-{\setkeys{multipleChoice}{#1}%
-\ifthenelse{\equal{\mc@id}{}}{}{\immediate\write\idfile{var \mc@id;}}%
-\begin{enumerate*}[before={\upshape{(\hspace{-.25em}}}, itemjoin={/\hspace{-.25em}}, after={\upshape{)}}, label={}]}
-{\end{enumerate*}}
+	{% Environment Start Code
+	\setkeys{multipleChoice}{#1}%
+	\ifthenelse{\equal{\mc@id}{}}% Test if \mc@ID is empty. This is not a robust check, is this dangerous? -- Jason
+		{}% Begin/End then result.
+		{% Begin else result
+		\immediate\write\idfile{var \mc@id;}
+		}% End else result
+	\begin{enumerate*}[before={\upshape{(\hspace{-.25em}}}, itemjoin={/\hspace{-.25em}}, after={\upshape{)}}, label={}]% Weird formatting choices, as stated displays "/" between items.
+	}
+	{% Environment End Code
+	\end{enumerate*}
+	}
 
 
 %multipleChoice** is for internal use only! (used in wordChoice)
@@ -663,7 +761,21 @@ Interactive
 
 %wordChoice is an in-line version of multipleChoice:  uses enumitem package
 %note, it is coded as a single line to avoid unwanted spaces in "given" mode
-\newcommand{\wordChoice}[1]{\let\choicetemp\choice\ifwordchoicegiven\def\choice{\otherchoice}\begin{multipleChoice**}#1\end{multipleChoice**}\else\begin{multipleChoice*}#1\end{multipleChoice*}\fi\let\choice\choicetemp}
+\newcommand{\wordChoice}[1]{%
+	\let\choicetemp\choice% Assign a "choicetemp" command to duplicate choice.
+	\ifwordchoicegiven
+		\def\choice{\otherchoice}
+		\begin{multipleChoice**}
+			#1
+		\end{multipleChoice**}
+	\else
+		\begin{multipleChoice*}
+			#1
+		\end{multipleChoice*}
+	\fi
+	\let\choice\choicetemp% Now that choicetmp has been manipulated to what we want, replace choice with it.
+	}
+
 
 \newenvironment{selectAll}[1][]
 {\begin{trivlist}\item[\hskip \labelsep\small\bfseries Select All Correct Answers:]\hfil\begin{enumerate}}
@@ -703,19 +815,43 @@ Interactive
 \ifhandout
 	\newenvironment{freeResponse}[1][false]%
 		{%
-		\def\givenatend{\boolean{#1}}\ifthenelse{\boolean{#1}}{\begin{trivlist}\item}{\setbox0\vbox\bgroup}{}
+		\def\givenatend{\boolean{#1}}
+		\ifthenelse{\boolean{#1}}
+			{% Begin then result
+			\begin{trivlist}
+				\item
+			}% End then result
+			{% Begin else result
+			\setbox0\vbox\bgroup
+			}% End else result
+%		{}% Don't think this is doing anything? -- Jason
 		}
 		{%
-		\ifthenelse{\givenatend}{\end{trivlist}}{\egroup}{}
+		\ifthenelse{\givenatend}
+			{% Begin then result
+			\end{trivlist}
+			}% End then result
+			{% Begin else result
+			\egroup
+			}% End else result
+%			{}% Don't think this is doing anything? -- Jason
 		}
 \else
 	\newenvironment{freeResponse}[1][false]%
-		{%
-		  \ifthenelse{\boolean{#1}}
-		  	{\begin{trivlist}\item[\hskip \labelsep\bfseries Free Response (Given):\hspace{2ex}]}
-			{\begin{trivlist}\item[\hskip \labelsep\bfseries Free Response:\hspace{2ex}]}
+		{% Environment Beginning Code
+		  \ifthenelse{\boolean{#1}}%% Could probably change this with just putting the (given) in the boolean?-- Jason
+		  	{% Begin then result
+		  	\begin{trivlist}
+		  		\item[\hskip \labelsep\bfseries Free Response (Given):\hspace{2ex}]
+		  	}% End then result
+			{% Begin else result
+			\begin{trivlist}
+				\item[\hskip \labelsep\bfseries Free Response:\hspace{2ex}]
+			}% End else result
 		}
-		{\end{trivlist}}
+		{% Environment Ending Code
+			\end{trivlist}
+		}
 \fi
 
 
@@ -725,10 +861,14 @@ Interactive
 	\ifinstructornotes
 		\newenvironment{instructorIntro}%
 			{%
-			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
+			\begin{trivlist}
+				\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
 			}
 			% %% line at the bottom} 
-			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+			{
+			\end{trivlist}
+			\par\addvspace{.5ex}\nobreak\noindent\hung
+			}
 	\else
 		\newenvironment{instructorIntro}%
 			{%
@@ -750,10 +890,14 @@ Interactive
 	\else
 		\newenvironment{instructorIntro}%
 			{%
-			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
+			\begin{trivlist}
+				\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
 			}
 			% %% line at the bottom} 
-			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+			{
+			\end{trivlist}
+			\par\addvspace{.5ex}\nobreak\noindent\hung
+			}
 	\fi
 \fi
 
@@ -765,10 +909,14 @@ Interactive
 	\ifinstructornotes
 		\newenvironment{instructorNotes}%
 			{%
-			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
+			\begin{trivlist}
+				\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
 			}
 			% %% line at the bottom} 
-			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+			{
+			\end{trivlist}
+			\par\addvspace{.5ex}\nobreak\noindent\hung
+			}
 	\else
 		\newenvironment{instructorNotes}%
 			{%
@@ -790,10 +938,14 @@ Interactive
 	\else
 		\newenvironment{instructorNotes}%
 			{%
-			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
+			\begin{trivlist}
+				\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
 			}
 			% %% line at the bottom} 
-			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+			{
+			\end{trivlist}
+			\par\addvspace{.5ex}\nobreak\noindent\hung
+			}
 	\fi
 \fi
 
@@ -817,6 +969,7 @@ Interactive
 %% You cannot use Environ with the fancyvrb/listings package if you want nested environments
 
 \DefineVerbatimEnvironment{python}{Verbatim}{numbers=left,frame=lines,label=Python,labelposition=topline}
+
 %% \lstnewenvironment{python}
 %%                   {\lstset{language=python,numbers=left}}
 %%                   {}
@@ -869,7 +1022,7 @@ Interactive
 %% Most of the below added by Jason Nowell
 
 \newcommand{\latexProblemContent}[1]{#1}%% Added for those that want to use UF problems without using the problem filter code. This command is renewed into something meaningful in the 'ProblemSelector.sty'.
-\newcounter{Iteration@probCnt}% Iterate count for problem counts.
+\Make@Counter{Iteration@probCnt}% Iterate count for problem counts.
 
 
 
@@ -879,6 +1032,8 @@ Interactive
 \newcommand{\problemNumber}{
 
 % First we determine if we have a counter for this question depth level.
+% -- Can probably replace this with Make@Counter at some point -- Jason
+
 \ifcsname c@depth\Roman{problem@Depth}Count\endcsname	% Check to see if counter exists
 	%If so, do nothing.
 	\else
@@ -904,14 +1059,16 @@ Interactive
 %%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%% Configure various problem environment commands
-\newcounter{problem@Depth}
-\setcounter{problem@Depth}{0}
-%Configure environments start content
+\Make@Counter{problem@Depth}
 
+
+
+%%%% Configure environments start content
 
 \newcommand{\problemEnvironmentStart}[2]{%
 % This takes in 2 arguments. 
 % The first is optional and is the old optional argument from existing environments. 
+%	This is passed down to the associated problem environment name in case you want a global value.
 % The second argument is mandatory and is the name of the 'problem' environment, 
 %	such as problem, question, exercise, etc. 
 % It then configures everything needed at the start of that environment.
@@ -923,13 +1080,15 @@ Interactive
   [%
 	\hskip\labelsep\sffamily\bfseries% 
 	#2%
-% Now we need to determine the correct number of the problem, and the format of that number.
-	\problemNumber
+	\problemNumber% Determine the correct number of the problem, and the format of that number.
 	]
 \slshape
 }
 
-%Configure environments end content
+
+
+%%%%% Configure environments end content
+
 \newcommand{\problemEnvironmentEnd}{%This configures all the end content for a problem.
 %
 % First we need to see if we've dropped fully out of a depth level, 
@@ -943,10 +1102,6 @@ Interactive
 
 \addtocounter{problem@Depth}{-2}% Exited a problem so we've exited a problem layer. Need -2 because we steppped once at the start to check for needing a depth-level count reset. 
 
-
-
-\ifhandout
-\fi %% space at end
 \par\addvspace{.5ex}\nobreak\noindent\hung %% line at the bottom
 
 \ifhandout
@@ -957,6 +1112,12 @@ Interactive
 \end{trivlist}
 }
 
+
+
+%%%% Now populate the old environment names
+%
+% Old environments were "problem", "exercise", "exploration", and "question".
+% Note that you can add content to the start/end code on top of these base code pieces if you want.
 
 
 \newenvironment{problem}[1][2in]%
@@ -991,6 +1152,8 @@ Interactive
 \problemEnvironmentEnd
 }
 
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%  				Validator			%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1014,7 +1177,9 @@ Interactive
 %\def\validator[#1]{\mbox{\texttt{\detokenize{#1}}}}
 %\def\endvalidator{}
 
-%% Feedback
+
+
+%%%% Feedback
 
 \ifhandout%	First, if it's a handout, we want feedback to eat everything and then disappear entirely. So we use the environ package to eat the content by not using \BODY command anywhere.
 %\NewEnviron{feedback}[1][]{}

--- a/ximera.cls
+++ b/ximera.cls
@@ -82,9 +82,13 @@
 \wordchoicegivenfalse
 \DeclareOption{wordchoicegiven}{\wordchoicegiventrue}
 
-\newif\ifspace 
-\spacefalse
-\DeclareOption{space}{\spacetrue}
+
+% "space" option depreciated. Keeping code in, in case of conflicts. Should remove this code if no conflicts are detected/reported by 6/28/2018 -- Jason Nowell
+%\newif\ifspace 
+%\spacefalse
+%\DeclareOption{space}{\spacetrue}
+
+
 %% This basically works for exercises, though page breaks are weird. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -114,36 +118,107 @@
 \ProcessOptions\relax
 \LoadClass{article}
 
-%%%% for allowing a ximera document to be input into a master ximera document
-%%%% SNAPP COMMENTED THIS OUT.
 
-%% % The first thing to do is to save the regular \LaTeX\ definitions of |\document|, |\enddocument|, and  |\documentclass|:
-%% %    \begin{macrocode}
-%% \let\old@document@subfiles\document
-%% \let\old@enddocument@subfiles\enddocument
-%% \let\old@documentclass@subfiles\documentclass
-%% %    \end{macrocode}
-%% %
-%% % Now the |document| `environment' is redefined and equaled to |comment|. As a consequence, the body of the main file is ignored by \LaTeX, and only the preamble is read (and anything that comes after |\end{document}|!). For |\documentclass|, having been already loaded one (|subfiles|), it is redefined and equaled to |\LoadClass|. The class and options of the main file are loaded identically.
-%% %    \begin{macrocode}
-%% \let\document\comment
-%% \let\enddocument\endcomment
-%% \let\documentclass\LoadClass\relax
-%% %    \end{macrocode}
-%% %
-%% % Here it comes something not so obvious. In the usual situations, the |\preamble@file| contains some |\usepackage| commands, which, at the end, make |@| no longer a letter. That is why the next part needs a |\catcode| command, grouping, and |\global|'s.
-%% %    \begin{macrocode}
-%% {\catcode`\@=11
-%% \global\let\document\old@document@subfiles
-%% \global\let\enddocument\old@enddocument@subfiles
-%% \global\let\documentclass\old@documentclass@subfiles
-%% \global\let\old@document@subfiles\undefined
-%% \global\let\old@enddocument@subfiles\undefined
-%% \global\let\old@documentclass@subfiles\undefined}
-%% %</class>
-%% %    \end{macrocode}
-%% %
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%						Required Packages
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% This is a list of required packages. As packages are added to this list, we should include a comment
+% as to where they are being utilized. This will help keep this list from being redundant and/or
+% outdated. -- Jason Nowell
+
+\RequirePackage[inline]{enumitem}
+\RequirePackage[pagestyles]{titlesec} 
+\RequirePackage{titletoc} 
+\RequirePackage{titling}  
+\RequirePackage{url}
+\RequirePackage{xcolor}
+\RequirePackage{pgfplots}
+\usepgfplotslibrary{groupplots}
+\usetikzlibrary{calc}
+\RequirePackage{fancyvrb}
+\RequirePackage{forloop}% Used for (at least) the problem environment dynamic naming and building.
+
+\RequirePackage{environ}% Included to allow saving of environment contents. This does *not* play well with various verbatem environments however and would be great to find a way around utilizing this package. One option is the "Suppress" command included below.
+\RequirePackage{amssymb}% Included to have access to math typeset.
+\RequirePackage{amsmath}% Included to have access to math typeset.
+\RequirePackage{amsthm}%  Included to have access to math typeset.
+\RequirePackage{xifthen}% http://ctan.org/pkg/xifthen
+\RequirePackage{multido}% http://ctan.org/pkg/multido
+\RequirePackage{listings} %% is this required???
+
+\RequirePackage{xkeyval}
+
+\RequirePackage[framemethod=TikZ]{mdframed} %% Used to make pretty foldable
+% BADBAD: the amsthm/mdframed conflict also messes up the .jax file
+
+\RequirePackage{comment}
+
+\oddsidemargin 62pt %% so we don't get weird margins in 2-sided mode
+\evensidemargin 62pt %% so we don't get weird margins in 2-sided mode
+\textwidth 345pt %% so we don't get weird margins in 2-sided mode
+\headheight 14pt %% so we don't get weird margins in 2-sided mode
+
+
+
+\makeatletter
+% Don't use hyperref when using Tex4ht
+\ifdefined\HCode
+\RequirePackage{hyperref}
+%\newcommand{\href}[1]{}
+\else
+\RequirePackage[pdfpagelabels,colorlinks=true,allcolors=blue!30!black]{hyperref}
+\pdfstringdefDisableCommands{\def\hskip{}}%% quiets warning
+\fi
+% We put hyperref after all other packages becuase that is better.
+
+% the article document class is made to have lines of text that are
+% not too long. 
+
+% http://tex.stackexchange.com/questions/71172/why-are-default-latex-margins-so-big
+
+
+% ---------------------------------------------------------------------
+% ---------------------------------------------------------------------
+% 				Custom Intrapackage Commands
+% ---------------------------------------------------------------------
+% ---------------------------------------------------------------------
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%  		Suppress Command  		%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%  
+% The suppress command is a good way to suppress output without commenting it.
+% This way we can avoid many of the places we use environ package and this should also
+% avoid most of the verbatim conflicts.
+%
+% Jason Nowell -- Code adapted from syntonly.sty
+
+
+\font\dummyft@=dummy \relax
+\def\suppress{%
+  \begingroup\par
+  \parskip\z@
+  \offinterlineskip
+  \baselineskip=\z@skip
+  \lineskip=\z@skip
+  \lineskiplimit=\maxdimen
+  \dummyft@
+  \count@\sixt@@n
+  \loop\ifnum\count@ >\z@
+    \advance\count@\m@ne
+    \textfont\count@\dummyft@
+    \scriptfont\count@\dummyft@
+    \scriptscriptfont\count@\dummyft@
+  \repeat
+  \let\selectfont\relax
+  \let\mathversion\@gobble
+  \let\getanddefine@fonts\@gobbletwo
+  \tracinglostchars\z@
+  \frenchspacing
+  \hbadness\@M}
+\def\endsuppress{\par\endgroup}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -162,8 +237,15 @@
 		}
 }
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% externalize tikz images
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%						Tikz Fix.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% Currently Tikz doesn't compile natively into the website because of how the xake bake compilation works.
+% ::IMPORTANT NOTE FOR TIKZ::
+% In order to make Tikz work, you need to get the tool "mutool" on the machine that is performing xake bake.
+
 \PassOptionsToPackage{table}{xcolor}
 \RequirePackage{tikz}
 
@@ -196,54 +278,8 @@
 % Load sagetex if it exists
 \IfFileExists{sagetex.sty}{\RequirePackage{sagetex}}{}
 
-\RequirePackage[inline]{enumitem}
-\RequirePackage[pagestyles]{titlesec} 
-\RequirePackage{titletoc} 
-\RequirePackage{titling}  
-\RequirePackage{url}
-\RequirePackage{xcolor}
-\RequirePackage{pgfplots}
-\usepgfplotslibrary{groupplots}
-\usetikzlibrary{calc}
-\RequirePackage{fancyvrb}
-%\RequirePackage{verbatim}
-\RequirePackage{environ}
-\RequirePackage{amssymb}
-\RequirePackage{amsmath}
-\RequirePackage{amsthm}
-\RequirePackage{xifthen}% http://ctan.org/pkg/xifthen
-\RequirePackage{multido}% http://ctan.org/pkg/multido
-\RequirePackage{listings} %% is this required???
-
-\RequirePackage{xkeyval}
-
-\RequirePackage[framemethod=TikZ]{mdframed} %% Used to make pretty foldable
-% BADBAD: the amsthm/mdframed conflict also messes up the .jax file
-
-\RequirePackage{comment}
-
-\oddsidemargin 62pt %% so we don't get weird margins in 2-sided mode
-\evensidemargin 62pt %% so we don't get weird margins in 2-sided mode
-\textwidth 345pt %% so we don't get weird margins in 2-sided mode
-\headheight 14pt %% so we don't get weird margins in 2-sided mode
 
 
-
-
-% Don't use hyperref when using Tex4ht
-\ifdefined\HCode
-\RequirePackage{hyperref}
-%\newcommand{\href}[1]{}
-\else
-\RequirePackage[pdfpagelabels,colorlinks=true,allcolors=blue!30!black]{hyperref}
-\pdfstringdefDisableCommands{\def\hskip{}}%% quiets warning
-\fi
-% We put hyperref after all other packages becuase that is better.
-
-% the article document class is made to have lines of text that are
-% not too long. 
-
-% http://tex.stackexchange.com/questions/71172/why-are-default-latex-margins-so-big
 
 % ---------------------------------------------------------------------
 % ---------------------------------------------------------------------
@@ -264,18 +300,18 @@
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{5pt}
 
-\makeatletter
+
 \let\title\relax
 \newcommand{\title}[1][]{{\protected@xdef\@pretitle{#1}}\protected@xdef\@title}
-\makeatother
+
 
 \title{}
 
-\makeatletter
+
 \let\abstract\relax
 \let\endabstract\relax
-\NewEnviron{abstract}{\protected@xdef\theabstract{\BODY}}
-\makeatother
+\NewEnviron{abstract}{\protected@xdef\theabstract{\BODY}}% Use of environ package, may want to find a better way.
+
 
 \newcounter{titlenumber}
 \renewcommand{\thetitlenumber}{\arabic{titlenumber}}
@@ -283,7 +319,7 @@
 \setcounter{titlenumber}{0}
 
 
-\makeatletter
+
 \newpagestyle{main}{
 \sethead[\textsl{\ifnumbers\thetitlenumber\quad\fi\@title}][][] % even
 {}{}{\textsl{\ifnumbers\thetitlenumber\quad\fi\@title}} % odd
@@ -291,10 +327,10 @@
 {}{}{\thepage} % odd
 }
 \pagestyle{main}
-\makeatother
+
 
 % Redefine maketitle and put them in a table of contents.  The \phantomsection is to fix the hrefs.
-\makeatletter
+
 \let\@emptyauthor\@author
 \def\author#1{\gdef\@author{#1}}
 \def\@author{\@latex@warning@no@line{No \noexpand\author given}}
@@ -309,7 +345,7 @@
   \ifnoauthor\else\let\thefootnote\relax\footnote{Author(s):~\@author}\fi
   \aftergroup\@afterindentfalse
   \aftergroup\@afterheading}
-\makeatother
+
 \relax
 
 \ifnumbers
@@ -317,18 +353,11 @@
 \renewcommand{\thesection}{\arabic{titlenumber}.\arabic{section}~} 
 \else
 \setcounter{secnumdepth}{-2}
-%\renewcommand{\thesection}{}
-%%magic to unindent unnumbered sections:
-%\makeatletter
-%\def\@seccntformat#1{\csname #1ignore\expandafter\endcsname\csname the#1\endcsname\quad}
-%\let\sectionignore\@gobbletwo
-%\let\latex@numberline\numberline
-%\def\numberline#1{\if\relax#1\relax\else\latex@numberline{#1}\fi}
-%\makeatother
+
 \fi
 \relax
 
-\makeatletter
+
 \def\activitystyle{}
 \newcounter{sectiontitlenumber}
 \setcounter{secnumdepth}{0}
@@ -351,7 +380,7 @@
     {\flushleft\Large\sffamily\bfseries\thetitlenumber.\thesectiontitlenumber\quad\@title \par}%
     {\vskip .6em\noindent\textit\theabstract}%
     \par\vspace{2em}}}
-\makeatother
+
 
 \iftikzexport%% allows xake to handle \chapterstyle and \sectionstye
 \renewcommand\chapterstyle{\def\activitystyle{chapter}}
@@ -361,11 +390,14 @@
 
 
 %% makes everymath display style even when inline, could be optional
-\everymath{\displaystyle} 
+\everymath{\displaystyle}
 %% Ok not everything, we also need this
 \let\prelim\lim 
 \renewcommand{\lim}{\displaystyle\prelim} 
 %% for display style limits
+
+
+
 
 % --------------------------------------------------------------------
 % --------------------------------------------------------------------
@@ -385,10 +417,6 @@
   \immediate\write\outcomefile{\unexpanded{\outcome}{#1}}}
 \fi%
 
-% --------------------------------------------------------------------
-% Videos
-
-%\newcommand{\video}[1]{\footnote{Video link: \url{#1}}}
 
 % Youtube link
 \newcommand{\youtube}[1]{YouTube link: \url{https://www.youtube.com/watch?v=#1}}
@@ -414,7 +442,7 @@
 \newcommand{\graph}[2][]{\text{Graph of $#2$}}
 
 % Interactive element
-\makeatletter
+
 \define@key{interactive}{id}{\def\interactive@id{#1}}
 \setkeys{interactive}{id=}
 \newcommand{\includeinteractive}[2][]{
@@ -422,7 +450,7 @@
 \ifthenelse{\equal{\interactive@id}{}}{}{\recordvariable{\interactive@id}}
 Interactive
 }
-\makeatother
+
 
 %HTML 
 \NewEnviron{html}{\textbf{INTERACTIVE NOT AVAILABLE.}}
@@ -485,31 +513,29 @@ Interactive
 
 %% Prompt environment
 \ifhandout
-\NewEnviron{prompt}{}
+	\newenvironment{prompt}{\suppress}{\endsuppress}
 \else
-\newenvironment{prompt}
-               {\bgroup\color{gray!50!black}}
-               {\egroup}
-               \fi
+	\newenvironment{prompt}
+    	{\bgroup\color{gray!50!black}}
+        {\egroup}
+\fi
 
-               %% Prompt environment
+%% onlineOnly environment
 \ifhandout
-\NewEnviron{onlineOnly}{\iftikzexport\BODY
-\else\fi}
+	\NewEnviron{onlineOnly}{
+	\iftikzexport
+		\BODY
+	\else
+	\fi
+	}
 \else
-\newenvironment{onlineOnly}
-               {\bgroup\color{red!50!black}}
-               {\egroup}
-               \fi
+	\newenvironment{onlineOnly}
+    	{\bgroup\color{red!50!black}}
+		{\egroup}
+\fi
                
-%\newenvironment{pdfOnly}{\iftikzexport\else}{\fi}
 \newcommand{\pdfOnly}[1]{\iftikzexport\else #1\fi}
  
-               
-
-%% \newenvironment{prompt} %broke in true math mode
-%%                {\ifhandout\setbox0\vbox\bgroup\else\bgroup\color{gray!50!black}\fi}
-%%                {\ifhandout\egroup\else\egroup\fi}
 
 % ---------------------------------------------------------------------
 % ---------------------------------------------------------------------
@@ -517,23 +543,33 @@ Interactive
 % ---------------------------------------------------------------------
 % ---------------------------------------------------------------------
 
-\makeatletter
+
 \ifdefined\HCode
-\newcommand{\recordvariable}[1]{}
+	\newcommand{\recordvariable}[1]{}
 \else
-\newwrite\idfile
-\immediate\openout\idfile=\jobname.ids
-\newcommand{\recordvariable}[1]{\ifthenelse{\equal{#1}{}}{}{\immediate\write\idfile{var #1;}}}
+	\newwrite\idfile
+	\immediate\openout\idfile=\jobname.ids
+	\newcommand{\recordvariable}[1]{\ifthenelse{\equal{#1}{}}{}{\immediate\write\idfile{var #1;}}}
 \fi
 
-%defining keys for answer command key=value pairs
-\define@key{answer}{given}[true]{\def\ans@given{#1}}
-\define@key{answer}{tolerance}{\def\ans@tol{#1}} %note: currently no affect on pdf output
-\define@key{answer}{validator}{}
-\define@key{answer}{id}{\def\ans@id{#1}} %note: currently no affect on pdf output
-\define@key{answer}{format}{}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% 	Defining keys for answer command key=value pairs
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%setting default values for answer command key=value pairs
+\define@key{answer}{given}[true]{\def\ans@given{#1}}% Determines if answer is shown in handout mode.
+\define@key{answer}{tolerance}{\def\ans@tol{#1}}% Used for setting numeric answer tolerance for online student input. 
+												 %  Note: currently no affect on pdf output.
+\define@key{answer}{validator}{}%			Used to run dynamic js code on student provided answers.
+\define@key{answer}{id}{\def\ans@id{#1}} %	Used for assigning a js ID to answer for dynamic code (eg validators).
+												 %  Note: currently no affect on pdf output.
+\define@key{answer}{format}{}%				Used to set anticipated input format; eg "string".
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%	Set default values for answer command key=value pairs
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \setkeys{answer}{id=,given=false}
 \newcommand{\answer}[2][]{%
   \ifmmode%
@@ -552,7 +588,7 @@ Interactive
   \fi
 }
              
-\makeatother
+
 
 %% multiple choice environment
 
@@ -565,7 +601,7 @@ Interactive
 \renewcommand{\labelenumii}{\theenumii}
 
 %% correct answers for multiple choice
-\makeatletter
+
 \define@key{choice}{value}[]{\def\choice@value{#1}}
 \define@boolkey{choice}{correct}[true]{\def\choice@correct{#1}}
 \setkeys{choice}{correct=false,value=}
@@ -577,11 +613,11 @@ Interactive
 \newcommand{\choiceEXP}[2][]{%
 \expandafter\setkeys\expandafter{choice}{#1}%
 \item{#2}\ifthenelse{\boolean{\choice@correct}}{\ifhandout \else \,\checkmark\,\setkeys{choice}{correct=false}\fi}{}} %% note all the {} are needed in case the choice has [] in it.
-\makeatother
+
 
 %% Not really meant to be used outside this package (used in wordChoice)
 %% \otherchoice outputs the item if correct and nothing if incorrect.
-\makeatletter
+
 \define@key{otherchoice}{value}[]{\def\otherchoice@value{#1}}
 \define@boolkey{otherchoice}{correct}[true]{\def\otherchoice@correct{#1}}
 \setkeys{otherchoice}{correct=false,value=}
@@ -589,11 +625,11 @@ Interactive
   \ignorespaces
   \setkeys{otherchoice}{#1}
   \ifthenelse{\boolean{\otherchoice@correct}}{#2\setkeys{otherchoice}{correct=false}}{}\ignorespaces}
-\makeatother
+
 %%%
 
 %setting default values for multipleChoice command key=value pairs
-\makeatletter
+
 \define@key{multipleChoice}{id}{\def\mc@id{#1}}
 \setkeys{multipleChoice}{id=}
 
@@ -610,7 +646,7 @@ Interactive
 \ifthenelse{\equal{\mc@id}{}}{}{\immediate\write\idfile{var \mc@id;}}%
 \begin{enumerate*}[before={\upshape{(\hspace{-.25em}}}, itemjoin={/\hspace{-.25em}}, after={\upshape{)}}, label={}]}
 {\end{enumerate*}}
-\makeatother
+
 
 %multipleChoice** is for internal use only! (used in wordChoice)
 %this is simply a wrapper for the sole showing (other)choice.
@@ -626,7 +662,7 @@ Interactive
 {\begin{trivlist}\item[\hskip \labelsep\small\bfseries Select All Correct Answers:]\hfil\begin{enumerate}}
 {\end{enumerate}\end{trivlist}}
 
-%% In the future we need this to (optionally) be desplayed in the
+%% In the future we need this to (optionally) be displayed in the
 %% problem, while the actual code lives in the solution. Here is how
 %% this could be implemented: Like the title/maketitle commands, the
 %% multiple-choice could be stored in \themultiplechoice, flip a
@@ -658,60 +694,60 @@ Interactive
 \setboolean{given}{true} %% could be replaced by a key=value pair later if needed
 
 \ifhandout
-\newenvironment{freeResponse}[1][false]%
-{%
-\def\givenatend{\boolean{#1}}\ifthenelse{\boolean{#1}}{\begin{trivlist}\item}{\setbox0\vbox\bgroup}{}
-}
-{%
-\ifthenelse{\givenatend}{\end{trivlist}}{\egroup}{}
-}
+	\newenvironment{freeResponse}[1][false]%
+		{%
+		\def\givenatend{\boolean{#1}}\ifthenelse{\boolean{#1}}{\begin{trivlist}\item}{\setbox0\vbox\bgroup}{}
+		}
+		{%
+		\ifthenelse{\givenatend}{\end{trivlist}}{\egroup}{}
+		}
 \else
-\newenvironment{freeResponse}[1][false]%
-{%
-  \ifthenelse{\boolean{#1}}{\begin{trivlist}\item[\hskip \labelsep\bfseries Free Response (Given):\hspace{2ex}]}
-{\begin{trivlist}\item[\hskip \labelsep\bfseries Free Response:\hspace{2ex}]}
-{}
-}
-{\end{trivlist}}
+	\newenvironment{freeResponse}[1][false]%
+		{%
+		  \ifthenelse{\boolean{#1}}
+		  	{\begin{trivlist}\item[\hskip \labelsep\bfseries Free Response (Given):\hspace{2ex}]}
+			{\begin{trivlist}\item[\hskip \labelsep\bfseries Free Response:\hspace{2ex}]}
+		}
+		{\end{trivlist}}
 \fi
 
 
 %% instructor intro/instructor notes
 %%
 \ifhandout % what follows is handout behavior
-\ifinstructornotes
-\newenvironment{instructorIntro}%
-{%
-  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
-}
-% %% line at the bottom} 
-{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
-\else
-\newenvironment{instructorIntro}%
-{%
-\setbox0\vbox\bgroup
-}
-{%
-\egroup\ignorespacesafterend %% If this mysteriously starts breaking remove \ignorespacesafterend
-}
-\fi
+	\ifinstructornotes
+		\newenvironment{instructorIntro}%
+			{%
+			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
+			}
+			% %% line at the bottom} 
+			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+	\else
+		\newenvironment{instructorIntro}%
+			{%
+			\setbox0\vbox\bgroup
+			}
+			{%
+			\egroup\ignorespacesafterend %% If this mysteriously starts breaking remove \ignorespacesafterend
+			}
+	\fi
 \else% for handout, so what follows is default
-\ifinstructornotes
-\newenvironment{instructorIntro}%
-{%
-\setbox0\vbox\bgroup
-}
-{%
-\egroup
-}
-\else
-\newenvironment{instructorIntro}%
-{%
-  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
-}
-% %% line at the bottom} 
-{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
-\fi
+	\ifinstructornotes
+		\newenvironment{instructorIntro}%
+			{%
+			\setbox0\vbox\bgroup
+			}
+			{%
+			\egroup
+			}
+	\else
+		\newenvironment{instructorIntro}%
+			{%
+			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Introduction:\hspace{2ex}]
+			}
+			% %% line at the bottom} 
+			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+	\fi
 \fi
 
 
@@ -719,56 +755,54 @@ Interactive
 
 %% instructorNotes environment
 \ifhandout % what follows is handout behavior
-\ifinstructornotes
-\newenvironment{instructorNotes}%
-{%
-  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
-}
-% %% line at the bottom} 
-{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
-\else
-\newenvironment{instructorNotes}%
-{%
-\setbox0\vbox\bgroup
-}
-{%
-\egroup
-}
-\fi
+	\ifinstructornotes
+		\newenvironment{instructorNotes}%
+			{%
+			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
+			}
+			% %% line at the bottom} 
+			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+	\else
+		\newenvironment{instructorNotes}%
+			{%
+			\setbox0\vbox\bgroup
+			}
+			{%
+			\egroup
+			}
+	\fi
 \else% for handout, so what follows is default
-\ifinstructornotes
-\newenvironment{instructorNotes}%
-{%
-\setbox0\vbox\bgroup
-}
-{%
-\egroup
-}
-\else
-\newenvironment{instructorNotes}%
-{%
-  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
-}
-% %% line at the bottom} 
-{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+	\ifinstructornotes
+		\newenvironment{instructorNotes}%
+			{%
+			\setbox0\vbox\bgroup
+			}
+			{%
+			\egroup
+			}
+	\else
+		\newenvironment{instructorNotes}%
+			{%
+			  \begin{trivlist}\item[\hskip \labelsep\bfseries Instructor Notes:\hspace{2ex}]
+			}
+			% %% line at the bottom} 
+			{\end{trivlist}\par\addvspace{.5ex}\nobreak\noindent\hung}
+	\fi
 \fi
-\fi
 
 
 
 
 
 
-
-
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%		Verbatim Environments for displaying programming code
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% code answer environment
 %% You cannot use Environ with the fancyvrb/listings package if you want nested environments
 
 \DefineVerbatimEnvironment{code}{Verbatim}{numbers=left,frame=lines,label=Code,labelposition=topline}
-
-
-
 
 
 
@@ -788,7 +822,7 @@ Interactive
 % The decoration for these environments were inspired by
 % http://tex.stackexchange.com/questions/11098/nice-formatting-for-theorems?lq=1
 
-%\makeatletter%
+%%
 \newcommand{\hang}{% top theorem decoration
   \begingroup%
   \setlength{\unitlength}{.005\linewidth}% \linewidth/200
@@ -830,7 +864,8 @@ Interactive
 \newcommand{\latexProblemContent}[1]{#1}%% Added for those that want to use UF problems without using the problem filter code. This command is renewed into something meaningful in the 'ProblemSelector.sty'.
 \newcounter{Iteration@probCnt}% Iterate count for problem counts.
 
-\RequirePackage{forloop}
+
+
 %%%%%% Configure environment configuration commands
 
 % The command \problemNumber contains all the format code to determine the number (and the format of the number) for any of the problem environments.
@@ -839,19 +874,12 @@ Interactive
 % First we determine if we have a counter for this question depth level.
 \ifcsname c@depth\Roman{problem@Depth}Count\endcsname	% Check to see if counter exists
 	%If so, do nothing.
-%	\newcounter{depthICount}
 	\else
 	%If not, create it.
 	\expandafter\newcounter{depth\Roman{problem@Depth}Count}
 	\expandafter\setcounter{depth\Roman{problem@Depth}Count}{0}
 	\fi
 
-
-
-% The problem ifnum check should be depreciated.
-%\ifnum\value{problem}<1
-%	\setcounter{problem}{1}% If the problem counter is ever 0 or negative, reset to one. This is a hack that should probably be more appropriately handled at some point but the problem counter is changed all over the place in this document.
-%\fi
 \expandafter\stepcounter{depth\Roman{problem@Depth}Count}
 \arabic{depthICount}% The first problem depth, what use to be "\theproblem".
 \forloop{Iteration@probCnt}{2}{\arabic{Iteration@probCnt} < \numexpr \value{problem@Depth} + 1 \relax}{%
@@ -873,10 +901,14 @@ Interactive
 \setcounter{problem@Depth}{0}
 %Configure environments start content
 
-%\newif\iffirstproblem Depreciated boolean.
-%\firstproblemtrue
 
-\newcommand{\problemEnvironmentStart}[2]{%This takes in 2 arguments. The first is optional and is the old optional argument from existing environments. The second argument is mandatory and is the name of the 'problem' environment, such as problem, question, exercise, etc. It then configures everything needed at the start of that environment.
+\newcommand{\problemEnvironmentStart}[2]{%
+% This takes in 2 arguments. 
+% The first is optional and is the old optional argument from existing environments. 
+% The second argument is mandatory and is the name of the 'problem' environment, 
+%	such as problem, question, exercise, etc. 
+% It then configures everything needed at the start of that environment.
+
 \stepcounter{problem@Depth}% Started a problem, so we've sunk another problem layer.
 \def\spaceatend{#1}%
 \begin{trivlist}%
@@ -892,9 +924,9 @@ Interactive
 
 %Configure environments end content
 \newcommand{\problemEnvironmentEnd}{%This configures all the end content for a problem.
-%\ifiscodeingTest
 %
-% First we need to see if we've dropped fully out of a depth level, so we can reset that counter back to zero for the next time we enter that depth level.
+% First we need to see if we've dropped fully out of a depth level, 
+% so we can reset that counter back to zero for the next time we enter that depth level.
 \stepcounter{problem@Depth}
 \ifcsname c@depth\Roman{problem@Depth}Count\endcsname
 	\expandafter\ifnum\expandafter\value{depth\Roman{problem@Depth}Count}>0
@@ -907,9 +939,6 @@ Interactive
 
 
 \ifhandout
-	\ifspace
-		\vspace{\spaceatend}
-	\fi
 \fi %% space at end
 \par\addvspace{.5ex}\nobreak\noindent\hung %% line at the bottom
 
@@ -958,13 +987,13 @@ Interactive
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%  				Validator			%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% New Validator code added by Jason Nowell
+% New Validator rewrite code added by Jason Nowell. Original code provided by Jim Fowler
 %
 % Validator is an environment designed to run a custom check on answers (usually) using javascript code. 
 
 
 % Define a placeholder command for validator and feedback.
-\makeatletter
+
 \newcommand{\PH@Command}{}
 
 %% Validator should take an argument and detokenize it and display it at the start of the environment. The original Validator environment had everything framed in an mbox; presumably to make the text look a bit nicer, although this seems redundant with texttt. It shouldn't cause any harm so I have left it in for now.
@@ -974,16 +1003,21 @@ Interactive
 	\mbox{\texttt{\detokenize\expandafter{\PH@Command}}}% Now expand PH@Command once and then detokenize. 
 	}{}
 
-%%% Old validator environment definition has been depreciated.
+%%% Old validator environment definition has been depreciated. -- remove by 5/28/2018 if no issues reported.
 %\def\validator[#1]{\mbox{\texttt{\detokenize{#1}}}}
 %\def\endvalidator{}
 
 %% Feedback
 
 \ifhandout%	First, if it's a handout, we want feedback to eat everything and then disappear entirely. So we use the environ package to eat the content by not using \BODY command anywhere.
-\NewEnviron{feedback}[1][]{}
+%\NewEnviron{feedback}[1][]{}
+% No! We are going to replace with the suppress command method. Delete the above old code by 6/28/2018 if no errors
+\newenvironment{feedback}{\suppress}{\endsuppress}
 
-\else% If this isn't a handout, then we want to display the Feedback by using a label, positioned and formated as a \item in a trivlist. It is important that we also detokenize the content of the optional argument, as it is likely to contain javascript or other code that latex won't be able to make sense of.
+\else% If this isn't a handout, then we want to display the Feedback by using a label, 
+%	positioned and formated as a \item in a trivlist. It is important that we also detokenize the content 
+%	of the optional argument, as it is likely to contain javascript or other code that latex won't be 
+%	able to make sense of.
 
 \newenvironment{feedback}[1][attempt]{
 
@@ -1000,7 +1034,7 @@ Interactive
 \fi
 
 
-%Old feedback code is retained below during depreciation period.
+%Old feedback code is retained below during depreciation period. -- delete by 5/28/2018 if no errors reported.
 
 %\ifhandout
 %
@@ -1020,7 +1054,7 @@ Interactive
                
 %\fi
 
-\makeatother               
+               
 
 
 %% Hints
@@ -1030,6 +1064,7 @@ Interactive
 %Create an empty shell to renew
 \newenvironment{hint}{}{}
 %Now we renew the environment as needed, this should allow support for any transition code that treats some parts as a "handout" and some parts as non-handout. 
+% renewing the environment on the fly is a bit hacky. Maybe we should have a hintHandout env or option.
 \renewenvironment{hint}
 	{
 	\ifhandout
@@ -1052,10 +1087,10 @@ Interactive
 	}
 
 \ifhints
-\renewenvironment{hint}{
-\begin{trivlist}\item[\hskip \labelsep\small\slshape\bfseries Hint:\hspace{2ex}]
-\small\slshape}
-{\end{trivlist}}
+	\renewenvironment{hint}{
+	\begin{trivlist}\item[\hskip \labelsep\small\slshape\bfseries Hint:\hspace{2ex}]
+	\small\slshape}
+	{\end{trivlist}}
 \fi
 
 
@@ -1155,7 +1190,7 @@ Interactive
     \immediate\openout\myfile=\jobname.jax
     \immediate\write\myfile{\unexpanded{\newenvironment}{prompt}{}{}}
 
-    \makeatletter
+    
 
 \let\@oldargdef\@argdef
 \long\def\@argdef#1[#2]#3{%
@@ -1166,5 +1201,9 @@ Interactive
 \let\@OldDeclareMathOperator\DeclareMathOperator
 \renewcommand{\DeclareMathOperator}[2]{\@OldDeclareMathOperator{#1}{#2}\immediate\write\myfile{\unexpanded{\DeclareMathOperator}{\unexpanded{#1}}{\unexpanded{#2}}}}
 
-    \makeatother
+    
 \fi
+
+
+
+\makeatother


### PR DESCRIPTION
Includes many fixes and formating changes to ximera.cls for readability. Most "removed" code is commented out with a note to check for conflicts and a date (so we can delete the commented code if no conflicts/errors are reported in the next 3 months).

Also added the new "Suppress" command which can suppress text output without using conditionals, in effect allowing us to suppress environment content without needing to use the environ package. Also works for verbatim content and the like to minimize conflicts from nesting (in theory).

Reorganized a few things to be able to find things in the cls file easier. Also added a \makeatletter at the top(ish) of the file and a \makeatother at the bottom. That way we can avoid having \makeatletter and \makeatother every dozen or so lines of code. I don't think this causes any issues, but may be something to watch for.

Added my name to various content in case someone has questions about the code, and added more comments for readability for other contributors.