### PR TITLE
Fixed TeX4ht support

### DIFF
--- a/ximera.4ht
+++ b/ximera.4ht
@@ -53,6 +53,8 @@
 \Configure{@HEAD}{\HCode{<meta name="author" content="}\@author\HCode{" />\Hnewline}}
 \def\and{and }
 
+% why do you remove \maketitle? does it produce errors? or you are not interested 
+% in titles in the HTML version?
 \renewcommand{\maketitle}{}
 
 
@@ -131,6 +133,10 @@
 
       \ConfigureTheoremEnv{warning}
 
+\ConfigureEnv{proof}{\ifvmode\IgnorePar\fi\EndP\HCode{<div class="proof">}
+\ConfigureList{trivlist}{\ifvmode\IgnorePar\fi\EndP}{}{}{}
+}{\ifvmode\IgnorePar\fi\EndP\HCode{</div>}}{}{}
+
 \newcounter{imagealt}
 \setcounter{imagealt}{0}
 \renewenvironment{image}[1][]{\stepcounter{imagealt}%
@@ -138,7 +144,7 @@
   \HCode{<div class="image-environment" role="img" aria-labelledby="image-alt-\arabic{imagealt}">}%
 }{\HCode{</div>}}
 \renewcommand{\alt}[1]{\HCode{<div style="display: none;" id="image-alt-\arabic{imagealt}">}#1\HCode{</div>}}
-\newcommand{\pgfsyspdfmark}[3]{}
+\providecommand{\pgfsyspdfmark}[3]{}
 \renewenvironment{dialogue}{\begin{description}}{\end{description}}
 
 \ConfigureList{dialogue}%
@@ -231,7 +237,7 @@
 \setkeys{geogebra}{rc=false,sdz=false,smb=false,stb=false,stbh=false,ld=false,sri=false}
 \renewcommand{\geogebra}[4][]{%
   \setkeys{geogebra}{#1}% Set new keys
-  \HCode{<iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/#2/width/#3/height/#4/border/888888/rc/\geo@rc/ai/false/sdz/\geo@sdz/smb/\geo@smb/stb/\geo@stb/stbh/\geo@stbh/ld/\geo@ld/sri/\geo@sri/at/auto" width="#3px" height="#4px" style="border:0px"></iframe>}}
+  \HCode{<iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/#2/width/#3/height/#4/border/888888/rc/\geo@rc/ai/false/sdz/\geo@sdz/smb/\geo@smb/stb/\geo@stb/stbh/\geo@stbh/ld/\geo@ld/sri/\geo@sri/at/auto" width="#3px" height="#4px" style="border:0px; max-width: fit-content"> </iframe>}}
 \renewcommand{\desmos}[3]{\HCode{<iframe src="https://www.desmos.com/calculator/#1" width="100\%" height="#3px" style="border: 1px solid \#ccc" frameborder=0>This browser does not support embedded elements.</iframe>}}
 \renewcommand{\desmosThreeD}[3]{\HCode{<iframe src="https://www.desmos.com/3d/#1" width="#2px" height="#3px" style="border: 1px solid \#ccc" frameborder=0>This browser does not support embedded elements.</iframe>}}
 
@@ -266,7 +272,9 @@
 \ScriptEnv{sageOutput}{\ifvmode \IgnorePar\fi \EndP\HCode{<div class="sageOutput"><script type="text/x-sage">}}{\HCode{\Hnewline</script></div>}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\renewenvironment{sagesilent}{\NoFonts}{\EndNoFonts}
+\ifdefined\sagesilent
+  \renewenvironment{sagesilent}{\NoFonts}{\EndNoFonts}
+\fi
 \ScriptEnv{sagesilent}{\ifvmode \IgnorePar\fi \EndP\HCode{<script type="text/sagemath">}\HtmlParOff}{\HtmlParOn\HCode{</script></div>}}
 \renewenvironment{ungraded}{%
 \ifvmode \IgnorePar\fi \EndP\HCode{<div class="ungraded">}\IgnoreIndent%

--- a/ximera.4ht
+++ b/ximera.4ht
@@ -77,11 +77,13 @@
 \ifthenelse{\equal{##1}{}}{}{%
   \HCode{<span class="theorem-like-title">}##1\HCode{</span>}%
 }}{}
-\ConfigureEnv{#1}{\stepcounter{identification}\ifvmode \IgnorePar\fi \EndP\HCode{<div class="theorem-like problem-environment #1" id="problem\arabic{identification}">}}{\HCode{</div>}\IgnoreIndent}{}{}%
+\ConfigureEnv{#1}{\stepcounter{identification}\ifvmode \IgnorePar\fi \EndP\HCode{<div class="theorem-like problem-environment #1" id="problem\arabic{identification}">}}{\ifvmode\IgnorePar\fi\EndP\HCode{</div>}\IgnoreIndent}{}{}%
 }
 
 
       \ConfigureTheoremEnv{theorem}
+
+      \ConfigureTheoremEnv{proof}
 
       \ConfigureTheoremEnv{algorithm}
 

--- a/ximera.cfg
+++ b/ximera.cfg
@@ -36,13 +36,13 @@
 
 \NoFonts
 
-\Configure{VERSION}{}
+%\Configure{VERSION}{}
 
-\Configure{DOCTYPE}{\HCode{<!doctype html>\Hnewline}}
+%\Configure{DOCTYPE}{\HCode{<!doctype html>\Hnewline}}
 
-\Configure{HTML}{\HCode{<html lang="en">\Hnewline}}{\HCode{\Hnewline</html>}}
+%\Configure{HTML}{\HCode{<html lang="en">\Hnewline}}{\HCode{\Hnewline</html>}}
 
-\Configure{@HEAD}{\HCode{<meta name="generator" content="TeX4ht (http://www.cse.ohio-state.edu/\string~gurari/TeX4ht/)" />\Hnewline}}
+%\Configure{@HEAD}{\HCode{<meta name="generator" content="TeX4ht (http://www.cse.ohio-state.edu/\string~gurari/TeX4ht/)" />\Hnewline}}
 \Configure{@HEAD}{\HCode{<meta name="ximera" content="version 0.0.1" />\Hnewline}}
 \Configure{@HEAD}{\HCode{<link href="https://ximera.osu.edu/public/stylesheets/standalone.css" rel="stylesheet" media="screen"/>\Hnewline}}
 \Configure{@HEAD}{\HCode{<script type="text/javascript" async src="https://ximera.osu.edu/public/javascripts/standalone.min.js"></script>\Hnewline}}
@@ -60,17 +60,28 @@
 \Configure{BODY}{%
 \HCode{<body>\Hnewline}%
 \Tg<div class="preamble">%
+\IfFileExists{\jobname.jax}{
 \Tg<script type="math/tex">%
 \BVerbatimInput{\jobname.jax}%
 \Tg</script>%
+}{}
 \IfFileExists{\jobname.ids}{\HCode{<script type="text/javascript">\Hnewline}%
 \BVerbatimInput{\jobname.ids}%
 \HCode{</script>\Hnewline}%
-\Tg</div>%
 }{}
+\Tg</div>%
 }{%
 \HCode{</body>\Hnewline}%
 }
+
+% contents of abstract is saved to a macro, but there are still tags for abstract, 
+% so we need to remove it
+\ConfigureEnv{abstract}{}{}{}{}
+
+% ToDo: take a look at these configurations
+% I think this should be updated with the current MathJax code from TeX4ht 
+% Maybe Ximera's JavaScript depends on the elmements this configuration inserts, 
+% so I am not removing it yet
 \newtoks\eqtoks
 \def\AltMath#1${\eqtoks{#1}%
         \HCode{<script type="math/tex">\the\eqtoks</script>}$}
@@ -111,14 +122,13 @@
   #1%
   \HCode{</span>}\par\IgnorePar}
 
-\let\abstract\relax
-\let\endabstract\relax
-\DeclareGraphicsExtensions{.jpg,.png,.gif,.svg}
-\Configure{graphics*}
-{svg}{
-  {\Configure{Needs}{File: \Gin@base.svg}\Needs{}}
-  \Picture[]{\csname Gin@base\endcsname.svg \csname a:Gin-dim\endcsname}%
-}
+% is this really necessary? SVG is now supported by TeX4ht
+% \DeclareGraphicsExtensions{.jpg,.png,.gif,.svg}
+% \Configure{graphics*}
+% {svg}{
+%   {\Configure{Needs}{File: \Gin@base.svg}\Needs{}}
+%   \Picture[]{\csname Gin@base\endcsname.svg \csname a:Gin-dim\endcsname}%
+% }
 \ifcsname ifstandalone\endcsname
   \ifstandalone
     \renewcommand\includegraphics[2][]{}

--- a/ximera.cfg
+++ b/ximera.cfg
@@ -71,7 +71,7 @@
 }{}
 \Tg</div>%
 }{%
-\HCode{</body>\Hnewline}%
+\ifvmode\IgnorePar\fi\EndP\HCode{</body>\Hnewline}%
 }
 
 % contents of abstract is saved to a macro, but there are still tags for abstract, 

--- a/ximera.cfg
+++ b/ximera.cfg
@@ -202,8 +202,8 @@
 \makeatother
 \renewenvironment{javascriptCode}{\NoFonts}{\EndNoFonts}
 \ScriptEnv{javascriptCode}{\stepcounter{identification}\ifvmode \IgnorePar\fi \EndP\HCode{<div class="javascript-code" id="javascript\arabic{identification}"><script type="text/text">}\HtmlParOff}{\HtmlParOn\HCode{\Hnewline</script></div>}}
-\ConfigureEnv{verbatim}{\HCode{<pre>}}{\HCode{</pre>}}{}{}
-\ConfigureEnv{lstlisting}{\HCode{<pre>}}{\HCode{</pre>}}{}{}
+\ConfigureEnv{verbatim}{\ifvmode\IgnorePar\fi\EndP\HCode{<pre>}}{\ifvmode\IgnorePar\fi\EndP\HCode{</pre>}}{}{}
+\ConfigureEnv{lstlisting}{\ifvmode\IgnorePar\fi\EndP\\HCode{<pre>}}{\ifvmode\IgnorePar\fi\EndP\HCode{</pre>}}{}{}
 \Configure{textbf}{\ifvmode\ShowPar\fi\HCode{<strong>}}{\HCode{</strong>}}
 \Configure{textit}{\ifvmode\ShowPar\fi\HCode{<em>}}{\HCode{</em>}}
 \Configure{emph}{\ifvmode\ShowPar\fi\HCode{<em>}}{\HCode{</em>}}

--- a/ximera.cfg
+++ b/ximera.cfg
@@ -32,7 +32,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\Preamble{xhtml}
+\Preamble{xhtml,mathjax}
 
 \NoFonts
 
@@ -78,40 +78,85 @@
 % so we need to remove it
 \ConfigureEnv{abstract}{}{}{}{}
 
-% ToDo: take a look at these configurations
-% I think this should be updated with the current MathJax code from TeX4ht 
-% Maybe Ximera's JavaScript depends on the elmements this configuration inserts, 
-% so I am not removing it yet
-\newtoks\eqtoks
-\def\AltMath#1${\eqtoks{#1}%
-        \HCode{<script type="math/tex">\the\eqtoks</script>}$}
-\Configure{$}{}{}{\expandafter\AltMath}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% These configurations were based on old TeX4ht MathJax support code
+% Below is a code that works with the current version
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% \newtoks\eqtoks
+% \long\def\AltMath#1${\eqtoks{#1}%
+%         \HCode{<script type="math/tex">\the\eqtoks</script>}$}
+% \Configure{$}{}{}{\expandafter\AltMath}
+% 
+% \long\def\AltlMathI#1\){\eqtoks{#1}%
+%         \HCode{<script type="math/tex">\the\eqtoks</script>}\)}
+% \Configure{()}{\AltlMathI}{}
+% 
+% \long\def\AltlDisplay#1\]{\eqtoks{#1}%
+%         \HCode{<script type="math/tex; mode=display">\the\eqtoks</script>}\]}
+% \Configure{[]}{\AltlDisplay}{}
+% 
+% \long\def\AltlDisplayI#1$${\eqtoks{#1}%
+%        \HCode{<script type="math/tex; mode=display">\the\eqtoks</script>}$$}
+% \Configure{$$}{}{}{\expandafter\AltlDisplayI}
 
-\def\AltlMathI#1\){\eqtoks{#1}%
-        \HCode{<script type="math/tex">\the\eqtoks</script>}\)}
-\Configure{()}{\AltlMathI}{}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\def\AltlDisplay#1\]{\eqtoks{#1}%
-        \HCode{<script type="math/tex; mode=display">\the\eqtoks</script>}\]}
-\Configure{[]}{\AltlDisplay}{}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% The following code is used to produce <script type="text/math">, but I am not sure if it is any better than the default MathJax 
+% support in TeX4ht. The rendering of Math seems to be much worse. It looks like an issue in Ximera's JavaScript code.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\catcode`\:=11
+\Configure{[]}{\HCode{<script type="math/tex">}\:HandleMathjaxCatcodes\catcode`\&=11\AltlDisplay}{\:RestoreMathjaxCatcodes\HCode{</script>}}
+\Configure{$}{\HCode{<script type="math/tex">}\:HandleMathjaxCatcodes}{\:RestoreMathjaxCatcodes\HCode{</script>}}{\expandafter\AltMathOne}
+\Configure{$$}{\HCode{<script type="math/tex">}\:HandleMathjaxCatcodes}{\:RestoreMathjaxCatcodes\HCode{</script>}}{\expandafter\AltlDisplayDollars}
+\Configure{()}{\HCode{<script type="math/tex">}\:HandleMathjaxCatcodes\catcode`\&=11\AltlMath}{\:RestoreMathjaxCatcodes\HCode{</script>}}
+\long\def\AltlMath#1\){\expandafter\alteqtoks{#1}\)}
+\long\def\AltlDisplay#1\]{\alteqtoks{#1}\]}
+\long\def\AltMathOne#1${\alteqtoks{#1}$}
+\long\def\AltlDisplayDollars#1$${\alteqtoks{#1}$$}
+\catcode`\:=12
 
-\def\AltlDisplayI#1$${\eqtoks{#1}%
-       \HCode{<script type="math/tex; mode=display">\the\eqtoks</script>}$$}
-\Configure{$$}{}{}{\expandafter\AltlDisplayI}
-\newcommand\VerbMath[1]{%
-\renewenvironment{#1}{\NoFonts}{\EndNoFonts}
-\ScriptEnv{#1}{\ifvmode \IgnorePar\fi \EndP\HCode{<script type="math/tex; mode=display"> \string\begin{#1}\Hnewline}\HtmlParOff}{\HtmlParOn\HCode{\string\end{#1}</script>}}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Handle VerbMath
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \newcommand\VerbMath[1]{%
+% \renewenvironment{#1}{\NoFonts}{\EndNoFonts}
+% \ScriptEnv{#1}{\ifvmode \IgnorePar\fi \EndP\HCode{<script type="math/tex; mode=display"> \string\begin{#1}\Hnewline}\HtmlParOff}{\HtmlParOn\HCode{\string\end{#1}</script>}}
+% }
+
+% Better version, based on TeX4ht sources, with <script type="text/math> tags
+\ExplSyntaxOn
+\renewcommand\VerbMath[2][]{%
+  \cs_if_exist:cTF{#2}{
+    \:savemathjaxenv{#2}%
+    \RenewDocumentEnvironment{#2}{+!b}{%
+      % we must use ~ instead of spaces in \ExplSyntaxOn
+      \ifvmode \IgnorePar\fi \EndP\HCode{<script~type="math/tex;~mode=display">}
+      \NoFonts\expandafter\VerbMathToks\expandafter{\detokenize{##1}}{#2}\EndNoFonts%
+      \HCode{</script>}
+      \ifx\relax#1\relax\else%
+      \refstepcounter{#1}%
+      \regex_extract_once:nVNTF { label\s* \x{7B}([^\x{7D}]*)\x{7D}} {\l_tmpb_tl} \l_tmp_seq {\label{\seq_item:Nn\l_tmp_seq{2}}} {}%
+      \fi
+    }{}
+  }{}%
 }
+\ExplSyntaxOff
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \ScriptEnv{matlabEquation}{\ifvmode \IgnorePar\fi \EndP\HCode{<script type="math/tex; mode=display"> \string\begin{equation}\Hnewline}\HtmlParOff}{\HtmlParOn\HCode{\string\end{equation}</script>}}
 
-\VerbMath{equation}
-\VerbMath{equation*}
-\VerbMath{align}
-\VerbMath{align*}
-\VerbMath{alignat}
-\VerbMath{alignat*}
-\VerbMath{eqnarray}
-\VerbMath{eqnarray*}
+%  This is not necessary, we can reuse all \VerbMath environments from TeX4ht 
+% \VerbMath{equation}
+% \VerbMath{equation*}
+% \VerbMath{align}
+% \VerbMath{align*}
+% \VerbMath{alignat}
+% \VerbMath{alignat*}
+% \VerbMath{eqnarray}
+% \VerbMath{eqnarray*}
+
 
 \renewcommand{\paragraph}[1]{%
   \HCode{<span class="paragraphHead">}%

--- a/ximera.cls
+++ b/ximera.cls
@@ -136,7 +136,8 @@
 
 \ifdefined\HCode
   \xaketrue%
-  \tikzexporttrue%
+  % dont't set tikz export in TeX4ht by default
+  % \tikzexporttrue%
   \handoutfalse%
   \numbersfalse%
   \newpagefalse%
@@ -173,7 +174,14 @@
 \RequirePackage{nameref}
 \RequirePackage{epstopdf}
 \ifdefined\HCode
-  \tikzexporttrue
+  % \tikzexporttrue
+  % TeX4ht creates SVG images for TikZ pictures by default. There is no need to explicitly
+  % use external graphics, unless explicitly requested by the user. 
+  % To speed up the compilation, it is possible to use the dvisvgm_hashes make4ht extension:
+  % $ make4ht -f html5+dvisvgm_hashes -c ximera.cfg -m draft filename.tex
+  % It compiles only images that were changed from previous runs and generates SVG images
+  % in paralel, so it is much faster than the default method which generates images sequentially.
+  \tikzexportfalse
 \fi
 
 \iftikzexport


### PR DESCRIPTION
I've updted `ximera.cfg`, `ximera.4ht` and `ximera.cls` to work with the current TeX4ht. There is a lot of changes, but the most important ones are related to MathJax - it reuses TeX4ht code, so it doesn't have issues with equations etc. Other changes are related to TikZ, as TeX4ht supports it out of the box, so there is no need to use externalization by default.

I've tested it on the `old-state` branch from [Ximera experimental repo](https://github.com/XimeraProject/ximeraExperimental/tree/old-state). All files now compile without errors, except for the `feedback.tex`, because lines like `  \begin{feedback}[y<17]` cause make4ht DOM filters to fail. It is caused by the `<` character, it thinks that it is a start of a HTML tag, so the parser gets confused. I've fixed this error in development versions of LuaXML and `make4ht`, but they are not in TeX Live yet.

There were some weird rendering errors for the stuff displayed using JavaScript when I displayed the HTML files, but I think these issues are on the JS side. Maybe they are caused by the fact that I am not viewing it in Ximera environment, but directly, so some CSS or JS is not used.

